### PR TITLE
Use period instead of hyphen for defining version

### DIFF
--- a/lib/twitter-typeahead-rails/version.rb
+++ b/lib/twitter-typeahead-rails/version.rb
@@ -1,7 +1,7 @@
 module Twitter
   module Typeahead
     module Rails
-      VERSION = "0.11.1-corejavascript"
+      VERSION = "0.11.1.corejavascript"
     end
   end
 end


### PR DESCRIPTION
Tried bundling on Demo with the `loop23/twitter-typeahead-rails` project and an exception was thrown:

```
Fetching source index from https://rubygems.org/
Fetching https://github.com/loop23/twitter-typeahead-rails.git
There was a ArgumentError while loading twitter-typeahead-rails.gemspec: 
Malformed version number string 0.11.1-corejavascript from
/data/examtime/shared/bundled_gems/ruby/2.0.0/bundler/gems/twitter-typeahead-rails-f200f9b8d2e5/twitter-typeahead-rails.gemspec:8:in
`block in <main>'

    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/servers.rb:85:in `run_on_each!'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/task.rb:74:in `run'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager/base.rb:37:in `block in run'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/task.rb:67:in `roles'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager/base.rb:36:in `run'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager/bundler.rb:53:in `install'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager.rb:72:in `block in install'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager.rb:52:in `each'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager.rb:52:in `each'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/dependency_manager.rb:72:in `install'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/deploy.rb:99:in `install_dependencies'
    from /usr/local/ey_resin/ruby/lib/ruby/gems/1.9.1/gems/engineyard-serverside-2.6.3/lib/engineyard-serverside/deploy.rb:95:in `bundle'
```
